### PR TITLE
build: add github CI linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: yarn install
+      - name: Run linting checks
+        run: yarn check


### PR DESCRIPTION
Add simple linting pipeline that will lint the code prior to merge using eslint and then prettier. This should enforce some basic standards across both our own and community contributions.