### PR TITLE
fix: uint64 rounding correction

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,7 @@ import { Address, BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts";
 export let EVENT_METADATA_STORAGE_ADDRESS_V1 = Address.fromString("0xcDA348fF8C175f305Ed8682003ec6F8743067f79");
 export let EVENT_METADATA_STORAGE_ADDRESS_V2 = Address.fromString("0x08C2aF3F01A36AD9F274ccE77f6f77cf9aa1dfC9");
 export let NFT_ADDRESS_V2 = Address.fromString("0xbce1b23c7544422f1E2208d29A6A3AA9fAbAB250");
+export let ECONOMICS_ADDRESS_V2 = Address.fromString("0x07faA643ad0eE4ee358d5E101573A5fdfBEcD0a9");
 export let ADDRESS_ZERO = Address.fromString("0x0000000000000000000000000000000000000000");
 
 // endBlock is not yet natively supported in subgraph.yaml meaning that we manually need to skip events for old ABI

--- a/src/mappings/v2/README.md
+++ b/src/mappings/v2/README.md
@@ -24,3 +24,7 @@ Unlike the V1 contracts thee eventAddress is no longer emitted with the PrimaryS
 ### 3. On-Chain Economics
 
 The on-chain economics and accounting of GET went live during the V2 contracts. This was enabled on block 20637829 and the economics fields should only be used from within an if statement allowing blocks greater than or equal to 20637829. Any events from blocks previous to this can be assumed to be for testing purposes only and should be set to 0. Transaction: https://polygonscan.com/tx/0xe9ef44375aa2a2cb70fb6244e60ca6c8ca60fca3dd6e0fa3b42e779d1d0faba3
+
+### 4. uint64 Accuracy
+
+In earlier versions of the contract gasUsed was chosen to be emitted as a uint64 rather than a uint256. Upon casting the uint256 gasUsed variable to a uint64 it rounds down to a floor set by the maximum precision available on a 64-bit integer. Over time this causes a slight drift in the amount of GET used as fuel in the fuel metrics. Future versions of the contract will emit a uint256 to avoid this issue. The workaround for this version is to fetch the fuel tank balance for each ticket after minting and use that as the getUsed. At this stage all actions to reduce the fuel tank balance will empty it in full, so we can assume that the getUsed for scanning and check-in is always equal to the fuel tank balance.

--- a/src/mappings/v2/baseGET.ts
+++ b/src/mappings/v2/baseGET.ts
@@ -5,6 +5,7 @@ import {
   BIG_INT_ONE,
   BIG_INT_ZERO,
   CURRENCY_CONVERSION_ACTIVATED_BLOCK,
+  ECONOMICS_ADDRESS_V2,
   FUEL_ACTIVATED_BLOCK,
   NFT_ADDRESS_V2,
 } from "../../constants";
@@ -17,6 +18,7 @@ import {
   SecondarySale,
   BaseGETV2 as BaseGETContractV2,
 } from "../../../generated/BaseGETV2/BaseGETV2";
+import { EconomicsGETV2 as EconomicsGETContractV2 } from "../../../generated/EconomicsGETV2/EconomicsGETV2";
 import {
   getProtocol,
   getRelayer,
@@ -74,25 +76,28 @@ export function handlePrimarySaleMint(e: PrimarySaleMint): void {
   event.mintCount = event.mintCount.plus(BIG_INT_ONE);
 
   if (e.block.number.ge(FUEL_ACTIVATED_BLOCK)) {
-    let getUsed = e.params.getUsed.divDecimal(BIG_DECIMAL_1E18);
+    let getUsedResult = EconomicsGETContractV2.bind(ECONOMICS_ADDRESS_V2).try_viewBackPackBalance(nftIndex);
 
-    protocol.getDebitedFromSilos = protocol.getDebitedFromSilos.plus(getUsed);
-    protocolDay.getDebitedFromSilos = protocolDay.getDebitedFromSilos.plus(getUsed);
-    relayer.getDebitedFromSilo = relayer.getDebitedFromSilo.plus(getUsed);
-    relayerDay.getDebitedFromSilo = relayerDay.getDebitedFromSilo.plus(getUsed);
-    event.getDebitedFromSilo = event.getDebitedFromSilo.plus(getUsed);
-    ticket.getDebitedFromSilo = ticket.getDebitedFromSilo.plus(getUsed);
+    if (!getUsedResult.reverted) {
+      let getUsed = getUsedResult.value.divDecimal(BIG_DECIMAL_1E18);
+      protocol.getDebitedFromSilos = protocol.getDebitedFromSilos.plus(getUsed);
+      protocolDay.getDebitedFromSilos = protocolDay.getDebitedFromSilos.plus(getUsed);
+      relayer.getDebitedFromSilo = relayer.getDebitedFromSilo.plus(getUsed);
+      relayerDay.getDebitedFromSilo = relayerDay.getDebitedFromSilo.plus(getUsed);
+      event.getDebitedFromSilo = event.getDebitedFromSilo.plus(getUsed);
+      ticket.getDebitedFromSilo = ticket.getDebitedFromSilo.plus(getUsed);
 
-    protocol.getHeldInFuelTanks = protocol.getHeldInFuelTanks.plus(getUsed);
-    relayer.getHeldInFuelTanks = relayer.getHeldInFuelTanks.plus(getUsed);
-    event.getHeldInFuelTanks = event.getHeldInFuelTanks.plus(getUsed);
-    ticket.getHeldInFuelTank = ticket.getHeldInFuelTank.plus(getUsed);
+      protocol.getHeldInFuelTanks = protocol.getHeldInFuelTanks.plus(getUsed);
+      relayer.getHeldInFuelTanks = relayer.getHeldInFuelTanks.plus(getUsed);
+      event.getHeldInFuelTanks = event.getHeldInFuelTanks.plus(getUsed);
+      ticket.getHeldInFuelTank = ticket.getHeldInFuelTank.plus(getUsed);
 
-    protocol.averageGetPerMint = protocol.getDebitedFromSilos.div(protocol.mintCount.toBigDecimal());
-    protocolDay.averageGetPerMint = protocolDay.getDebitedFromSilos.div(protocolDay.mintCount.toBigDecimal());
-    relayer.averageGetPerMint = relayer.getDebitedFromSilo.div(relayer.mintCount.toBigDecimal());
-    relayerDay.averageGetPerMint = relayerDay.getDebitedFromSilo.div(relayerDay.mintCount.toBigDecimal());
-    event.averageGetPerMint = event.getDebitedFromSilo.div(event.mintCount.toBigDecimal());
+      protocol.averageGetPerMint = protocol.getDebitedFromSilos.div(protocol.mintCount.toBigDecimal());
+      protocolDay.averageGetPerMint = protocolDay.getDebitedFromSilos.div(protocolDay.mintCount.toBigDecimal());
+      relayer.averageGetPerMint = relayer.getDebitedFromSilo.div(relayer.mintCount.toBigDecimal());
+      relayerDay.averageGetPerMint = relayerDay.getDebitedFromSilo.div(relayerDay.mintCount.toBigDecimal());
+      event.averageGetPerMint = event.getDebitedFromSilo.div(event.mintCount.toBigDecimal());
+    }
   }
 
   protocol.save();
@@ -121,7 +126,7 @@ export function handleTicketInvalidated(e: TicketInvalidated): void {
   event.invalidateCount = event.invalidateCount.plus(BIG_INT_ONE);
 
   if (e.block.number.ge(FUEL_ACTIVATED_BLOCK)) {
-    let getUsed = e.params.getUsed.divDecimal(BIG_DECIMAL_1E18);
+    let getUsed = ticket.getHeldInFuelTank;
 
     protocol.getCreditedToDepot = protocol.getCreditedToDepot.plus(getUsed);
     protocolDay.getCreditedToDepot = protocolDay.getCreditedToDepot.plus(getUsed);
@@ -186,7 +191,7 @@ export function handleTicketScanned(e: TicketScanned): void {
   event.scanCount = event.scanCount.plus(BIG_INT_ONE);
 
   if (e.block.number.ge(FUEL_ACTIVATED_BLOCK)) {
-    let getUsed = e.params.getUsed.divDecimal(BIG_DECIMAL_1E18);
+    let getUsed = ticket.getHeldInFuelTank;
 
     protocol.getCreditedToDepot = protocol.getCreditedToDepot.plus(getUsed);
     protocolDay.getCreditedToDepot = protocolDay.getCreditedToDepot.plus(getUsed);
@@ -227,7 +232,7 @@ export function handleCheckedIn(e: CheckedIn): void {
   event.claimCount = event.claimCount.plus(BIG_INT_ONE);
 
   if (e.block.number.ge(FUEL_ACTIVATED_BLOCK)) {
-    let getUsed = e.params.getUsed.divDecimal(BIG_DECIMAL_1E18);
+    let getUsed = ticket.getHeldInFuelTank;
 
     protocol.getCreditedToDepot = protocol.getCreditedToDepot.plus(getUsed);
     protocolDay.getCreditedToDepot = protocolDay.getCreditedToDepot.plus(getUsed);

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -34,40 +34,6 @@ dataSources:
           handler: handleNftClaimed
       file: ./src/mappings/v1/baseGET.ts
   - kind: ethereum/contract
-    name: BaseGETV2
-    network: matic
-    source:
-      address: "0xbce1b23c7544422f1E2208d29A6A3AA9fAbAB250"
-      abi: BaseGETV2
-      startBlock: 20363107
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.5
-      language: wasm/assemblyscript
-      entities:
-        - PrimarySaleMint
-        - TicketInvalidated
-        - TicketScanned
-        - CheckedIn
-        - NftClaimed
-      abis:
-        - name: BaseGETV2
-          file: ./abis/v2/BaseGET.json
-      eventHandlers:
-        - event: PrimarySaleMint(indexed uint256,indexed uint64,indexed uint64,uint256)
-          handler: handlePrimarySaleMint
-        - event: TicketInvalidated(indexed uint256,indexed uint64,indexed uint64)
-          handler: handleTicketInvalidated
-        - event: SecondarySale(indexed uint256,indexed uint64,indexed uint64,uint256)
-          handler: handleSecondarySale
-        - event: TicketScanned(indexed uint256,indexed uint64,indexed uint64)
-          handler: handleTicketScanned
-        - event: CheckedIn(indexed uint256,indexed uint64,indexed uint64)
-          handler: handleCheckedIn
-        - event: NftClaimed(indexed uint256,indexed uint64,indexed uint64)
-          handler: handleNftClaimed
-      file: ./src/mappings/v2/baseGET.ts
-  - kind: ethereum/contract
     name: EventMetadataStorageV1
     network: matic
     source:
@@ -87,6 +53,42 @@ dataSources:
         - event: newEventRegistered(indexed address,indexed uint256,string,indexed uint256)
           handler: handleNewEventRegistered
       file: ./src/mappings/v1/eventMetadataStorage.ts
+  - kind: ethereum/contract
+    name: BaseGETV2
+    network: matic
+    source:
+      address: "0xbce1b23c7544422f1E2208d29A6A3AA9fAbAB250"
+      abi: BaseGETV2
+      startBlock: 20363107
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - PrimarySaleMint
+        - TicketInvalidated
+        - TicketScanned
+        - CheckedIn
+        - NftClaimed
+      abis:
+        - name: BaseGETV2
+          file: ./abis/v2/BaseGET.json
+        - name: EconomicsGETV2
+          file: ./abis/v2/EconomicsGET.json
+      eventHandlers:
+        - event: PrimarySaleMint(indexed uint256,indexed uint64,indexed uint64,uint256)
+          handler: handlePrimarySaleMint
+        - event: TicketInvalidated(indexed uint256,indexed uint64,indexed uint64)
+          handler: handleTicketInvalidated
+        - event: SecondarySale(indexed uint256,indexed uint64,indexed uint64,uint256)
+          handler: handleSecondarySale
+        - event: TicketScanned(indexed uint256,indexed uint64,indexed uint64)
+          handler: handleTicketScanned
+        - event: CheckedIn(indexed uint256,indexed uint64,indexed uint64)
+          handler: handleCheckedIn
+        - event: NftClaimed(indexed uint256,indexed uint64,indexed uint64)
+          handler: handleNftClaimed
+      file: ./src/mappings/v2/baseGET.ts
   - kind: ethereum/contract
     name: EventMetadataStorageV2
     network: matic


### PR DESCRIPTION
The gasUsed argument on each emitted event on the v2 contracts is a uint64 cast from a source of uint256, causing some inaccuracy. This results in 'rounding down' to the floor of the uint64 precision for each ticket minted causing a slight drift in the aggregated values over time. For obvious reasons the gasUsed needs to be 100% accurate and will be emitted as a uint256 in future versions of the contract.

The workaround here is to fetch the fuel tank balance of the NFT after minting as this is returned as a uint256. Scanning, checking-in, and invalidating all clear the fuel tank, so the existing fuel tank balance can be used as the value of gasUsed for these actions.

See v2 README.md comment for more.