### PR TITLE
feat: add testing environment

### DIFF
--- a/config/testing.json
+++ b/config/testing.json
@@ -1,0 +1,25 @@
+{
+  "network": "mumbai",
+  "fuelActivatedBlock": 20198770,
+  "v1EndBlock": 20206901,
+  "BaseGETV1": {
+    "address": "0xdD1dd60661e26ab34db1f89c9fE5f5B578f8388b",
+    "startBlock": 14955208
+  },
+  "EventMetadataStorageV1": {
+    "address": "0x535d2aa374f8d9ce4D6fF68938b1A75642328cF6",
+    "startBlock": 14955196
+  },
+  "BaseGETV2": {
+    "address": "0x1c7a119c851DE77DD9A19b4a629861Ec03929f06",
+    "startBlock": 20190398
+  },
+  "EventMetadataStorageV2": {
+    "address": "0x1c9a79D553ABE5D52c64BD5F1007C47DBCcC21c5",
+    "startBlock": 20190412
+  },
+  "EconomicsGETV2": {
+    "address": "0x5c26C062C74Cec95Bb155DE172EdAd3dC02713cc",
+    "startBlock": 20190406
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "scripts": {
     "codegen": "graph codegen",
     "create:local": "graph create --node http://localhost:8020/ get-protocol-subgraph",
+    "prepare:testing": "mustache config/testing.json subgraph.yaml.mustache > subgraph.yaml && mustache config/testing.json src/constants/contracts.ts.mustache > src/constants/contracts.ts",
     "prepare:playground": "mustache config/playground.json subgraph.yaml.mustache > subgraph.yaml && mustache config/playground.json src/constants/contracts.ts.mustache > src/constants/contracts.ts",
     "prepare:production": "mustache config/production.json subgraph.yaml.mustache > subgraph.yaml && mustache config/production.json src/constants/contracts.ts.mustache > src/constants/contracts.ts",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 get-protocol-subgraph",
+    "deploy:testing": "graph deploy --product hosted-service getprotocol/testing-get-protocol-subgraph",
     "deploy:playground": "graph deploy --product hosted-service getprotocol/playground-get-protocol-subgraph",
     "deploy:production": "graph deploy --product hosted-service getprotocol/get-protocol-subgraph",
     "build": "graph build",


### PR DESCRIPTION
Testing environment config added, to be deployed in the same way as playground and production with the added npm scripts in package.json