### PR TITLE
fix: divide-by-zero on secondary sale

### DIFF
--- a/src/entities/integratorDay.ts
+++ b/src/entities/integratorDay.ts
@@ -66,8 +66,10 @@ export function updateSecondarySale(
   integratorDay.resoldCount = integratorDay.resoldCount.plus(count);
   integratorDay.reservedFuel = integratorDay.reservedFuel.plus(reservedFuel);
   integratorDay.reservedFuelProtocol = integratorDay.reservedFuelProtocol.plus(reservedFuelProtocol);
-  integratorDay.averageReservedPerTicket = integratorDay.reservedFuel.div(integratorDay.soldCount.toBigDecimal());
   integratorDay.availableFuel = integrator.availableFuel;
+  if (integratorDay.soldCount.gt(BIG_INT_ZERO)) {
+    integratorDay.averageReservedPerTicket = integratorDay.reservedFuel.div(integratorDay.soldCount.toBigDecimal());
+  }
   integratorDay.save();
 }
 

--- a/src/entities/protocolDay.ts
+++ b/src/entities/protocolDay.ts
@@ -48,7 +48,9 @@ export function updateSecondarySale(e: ethereum.Event, count: BigInt, reservedFu
   protocolDay.resoldCount = protocolDay.resoldCount.plus(count);
   protocolDay.reservedFuel = protocolDay.reservedFuel.plus(reservedFuel);
   protocolDay.reservedFuelProtocol = protocolDay.reservedFuelProtocol.plus(reservedFuelProtocol);
-  protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
+  if (protocolDay.soldCount.gt(BIG_INT_ZERO)) {
+    protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
+  }
   protocolDay.save();
 }
 


### PR DESCRIPTION
Nasty bug wherein a resold ticket being the first action of the day can brick the subgraph. This is because to calculate the average GET fuel per-ticket we must divide by the number of tickets minted that day, which can be zero.

This fixes the handling so that the average fuel per-day is only set when the sold count for that day is greater than 0.