### PR TITLE
fix: current spent fuel calculations

### DIFF
--- a/config/polygon-production.json
+++ b/config/polygon-production.json
@@ -2,7 +2,7 @@
   "chainName": "polygon",
   "network": "matic",
   "graft": {
-    "base": "Qmbn852nmXZnAzHRk8iMN8Qs3uqrz5gxAPDoQ4S1Ctvhpi",
+    "base": "QmUJkxTfn1CBTSdZQHCQR6KZnGjq4uPYo1fGk8DEUGjDRV",
     "block": 29585037
   },
   "relayers": [

--- a/src/entities/protocol.ts
+++ b/src/entities/protocol.ts
@@ -65,6 +65,8 @@ export function updateScanned(count: BigInt): void {
 export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
   let protocol = getProtocol();
   protocol.checkedInCount = protocol.checkedInCount.plus(count);
+  protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
+  protocol.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol.plus(spentFuelProtocol);
   protocol.spentFuel = protocol.spentFuel.plus(spentFuel);
   protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(spentFuelProtocol);
   protocol.currentReservedFuel = protocol.currentReservedFuel.minus(spentFuel);
@@ -75,6 +77,8 @@ export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelP
 export function updateInvalidated(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
   let protocol = getProtocol();
   protocol.invalidatedCount = protocol.invalidatedCount.plus(count);
+  protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
+  protocol.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol.plus(spentFuelProtocol);
   protocol.spentFuel = protocol.spentFuel.plus(spentFuel);
   protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(spentFuelProtocol);
   protocol.currentReservedFuel = protocol.currentReservedFuel.minus(spentFuel);

--- a/src/entities/ticket.ts
+++ b/src/entities/ticket.ts
@@ -51,6 +51,8 @@ function calculateReservedFuel(
   //     _fuel += (_fuelUsd * 1e18) / integrator.price;
   // }
 
+  if (price.equals(BIG_DECIMAL_ZERO)) return BIG_DECIMAL_ZERO;
+
   let fuelUsd = basePrice.times(rate).div(BigDecimal.fromString("100"));
 
   if (fuelUsd.lt(minFee)) {
@@ -86,5 +88,6 @@ export function calculateReservedFuelSecondary(ticket: Ticket, integrator: Integ
 // This may change to be ticket-specific in future.
 export function calculateReservedFuelProtocol(_ticket: Ticket, integrator: Integrator): BigDecimal {
   let protocol = getProtocol();
+  if (integrator.price.equals(BIG_DECIMAL_ZERO)) return BIG_DECIMAL_ZERO;
   return protocol.minFeePrimary.div(integrator.price);
 }

--- a/src/mappings/v1.1/baseGET.ts
+++ b/src/mappings/v1.1/baseGET.ts
@@ -218,7 +218,7 @@ export function handleSecondarySale(e: SecondarySale): void {
 
   protocol.resoldCount = protocol.resoldCount.plus(BIG_INT_ONE);
   protocolDay.resoldCount = protocolDay.resoldCount.plus(BIG_INT_ONE);
-  integrator.resoldCount = integratorDay.resoldCount.plus(BIG_INT_ONE);
+  integrator.resoldCount = integrator.resoldCount.plus(BIG_INT_ONE);
   integratorDay.resoldCount = integratorDay.resoldCount.plus(BIG_INT_ONE);
   event.resoldCount = event.resoldCount.plus(BIG_INT_ONE);
 


### PR DESCRIPTION
Current spent fuel is not correctly tracked on the protocol entities and should be increased upon every ticket check-in and invalidation. This is already set to 0 when collecting the spent fuel.