### PR TITLE
improving fee and revenue tracking

### DIFF
--- a/abis/v2/Economics.json
+++ b/abis/v2/Economics.json
@@ -634,6 +634,25 @@
       },
       {
         "indexed": false,
+        "internalType": "bool",
+        "name": "onCredit",
+        "type": "bool"
+      }
+    ],
+    "name": "UpdateIntegratorOnCredit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "integratorIndex",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "price",
         "type": "uint256"
@@ -752,6 +771,19 @@
       }
     ],
     "name": "UpdateSpentFuel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "spentFuelOnCredit",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdateSpentFuelOnCredit",
     "type": "event"
   },
   {
@@ -905,6 +937,11 @@
     "inputs": [],
     "name": "collectSpentFuel",
     "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "",
@@ -1084,6 +1121,11 @@
         "internalType": "string",
         "name": "name",
         "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "onCredit",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -1527,6 +1569,24 @@
         "type": "uint32"
       },
       {
+        "internalType": "bool",
+        "name": "_onCredit",
+        "type": "bool"
+      }
+    ],
+    "name": "setIntegratorOnCredit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_integratorIndex",
+        "type": "uint32"
+      },
+      {
         "internalType": "uint256",
         "name": "_price",
         "type": "uint256"
@@ -1641,6 +1701,11 @@
         "internalType": "struct IEconomics.SpentFuel",
         "name": "_spentFuel",
         "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_spentFuelOnCredit",
+        "type": "uint256"
       }
     ],
     "name": "setSpentFuel",
@@ -1789,6 +1854,19 @@
         "internalType": "uint32",
         "name": "ticketCount",
         "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spentFuelOnCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/config/polygon-development.json
+++ b/config/polygon-development.json
@@ -1,6 +1,11 @@
 {
   "chainName": "mumbai",
   "network": "mumbai",
+  "addresses": {
+    "GETSaaS":"0x0000000000000000000000000000000000000001",
+    "Staking": "0xbf7f1625E74D64a0f380a2C887F17F9BdC3d518D",
+    "FuelBridgeReceiver": "0xa4d622434f677cfc58BaFd23c16B6fc57bA845Ce"
+  },
   "v2": {
     "Economics": {
       "address": "0xCD50e54A3Ee1374d8c805b128a06C91475e1720F",

--- a/config/polygon-playground.json
+++ b/config/polygon-playground.json
@@ -1,6 +1,11 @@
 {
   "chainName": "polygon",
   "network": "matic",
+  "addresses": {
+    "GETSaaS":"0xba0eae2aA4CB751D063E52Cf988E179c7d38E90C",
+    "Staking": "0x3e49E9C890Cd5B015A18ed76E7A4093f569f1A04",
+    "FuelBridgeReceiver": "0x5339D13e0C5f88A4194B2D80594F4cB870BAd8bf"
+  },
   "v2": {
     "Economics": {
       "address": "0xe7F784799479fcFAF4A2d83E1880Df774e56A9bd",

--- a/config/polygon-production.json
+++ b/config/polygon-production.json
@@ -31,6 +31,11 @@
     ["ontapp tickets", "13"],
     ["neonox", "14"]
   ],
+  "addresses": {
+    "GETSaaS":"0xba0eae2aA4CB751D063E52Cf988E179c7d38E90C",
+    "Staking": "0x3e49E9C890Cd5B015A18ed76E7A4093f569f1A04",
+    "FuelBridgeReceiver": "0x5339D13e0C5f88A4194B2D80594F4cB870BAd8bf"
+  },
   "v1": {
     "BaseGET": {
       "address": "0x308e44cA2153C61103b0DC67Fd038De650912b73",

--- a/config/polygon-testing.json
+++ b/config/polygon-testing.json
@@ -15,6 +15,11 @@
     ["wicket", "4"],
     ["tectix", "5"]
   ],
+  "addresses": {
+    "GETSaaS":"0x0000000000000000000000000000000000000001",
+    "Staking": "0xbf7f1625E74D64a0f380a2C887F17F9BdC3d518D",
+    "FuelBridgeReceiver": "0xa4d622434f677cfc58BaFd23c16B6fc57bA845Ce"
+  },
   "v1": {
     "BaseGET": {
       "address": "0xdD1dd60661e26ab34db1f89c9fE5f5B578f8388b",

--- a/schema.graphql
+++ b/schema.graphql
@@ -41,6 +41,8 @@ type Protocol @entity {
   checkedInCount: BigInt!
   claimedCount: BigInt!
   minFeePrimary: BigDecimal!
+  treasuryRevenue: BigDecimal!
+  holdersRevenue: BigDecimal!
 }
 
 type ProtocolDay @entity {
@@ -64,6 +66,8 @@ type ProtocolDay @entity {
   scannedCount: BigInt!
   checkedInCount: BigInt!
   claimedCount: BigInt!
+  treasuryRevenue: BigDecimal!
+  holdersRevenue: BigDecimal!
 }
 
 type Integrator @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -84,6 +84,7 @@ type Integrator @entity {
   activeTicketCount: Int!
   isBillingEnabled: Boolean!
   isConfigured: Boolean!
+  isOnCredit: Boolean!
   minFeePrimary: BigDecimal!
   maxFeePrimary: BigDecimal!
   primaryRate: BigDecimal!

--- a/schema.graphql
+++ b/schema.graphql
@@ -101,6 +101,8 @@ type Integrator @entity {
   scannedCount: BigInt!
   checkedInCount: BigInt!
   claimedCount: BigInt!
+  treasuryRevenue: BigDecimal!
+  holdersRevenue: BigDecimal!
   relayers: [Relayer!]! @derivedFrom(field: "integrator")
   events: [Event!]! @derivedFrom(field: "integrator")
   tickets: [Ticket!]! @derivedFrom(field: "integrator")
@@ -128,6 +130,8 @@ type IntegratorDay @entity {
   scannedCount: BigInt!
   checkedInCount: BigInt!
   claimedCount: BigInt!
+  treasuryRevenue: BigDecimal!
+  holdersRevenue: BigDecimal!
 }
 
 type Relayer @entity {

--- a/src/constants/contracts.ts.mustache
+++ b/src/constants/contracts.ts.mustache
@@ -5,6 +5,8 @@ import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export let CHAIN_NAME = "{{ chainName }}".toUpperCase();
 export let CURRENCY_CONVERSION_ACTIVATED_BLOCK = BigInt.fromI32(20410204);
+export let GUTS_ON_CREDIT_DAY = 19338
+export let GUTS_INTEGRATOR_ID = "4"
 export let GUTS_ON_CREDIT_BLOCK = BigInt.fromI32(39300544);
 export let STAKING_INIT_BLOCK = BigInt.fromI32(38542794);
 export let FUEL_BRIDGE_RECEIVER = Address.fromString("{{ addresses.FuelBridgeReceiver }}");

--- a/src/constants/contracts.ts.mustache
+++ b/src/constants/contracts.ts.mustache
@@ -5,6 +5,10 @@ import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export let CHAIN_NAME = "{{ chainName }}".toUpperCase();
 export let CURRENCY_CONVERSION_ACTIVATED_BLOCK = BigInt.fromI32(20410204);
+export let GUTS_ON_CREDIT_BLOCK = BigInt.fromI32(39300544);
+export let FUEL_BRIDGE_RECEIVER = Address.fromString("{{ addresses.FuelBridgeReceiver }}");
+export let STAKING = Address.fromString("{{ addresses.Staking }}");
+export let GET_SAAS = Address.fromString("{{ addresses.GETSaaS }}")
 export let EVENT_METADATA_STORAGE_ADDRESS_V1 = {{ ^v1.EventMetadataStorage.address }}Address.zero(){{ /v1.EventMetadataStorage.address }}{{ #v1.EventMetadataStorage.address }}Address.fromString("{{ v1.EventMetadataStorage.address }}"){{ /v1.EventMetadataStorage.address }};
 export let EVENT_METADATA_STORAGE_ADDRESS_V1_1 = {{ ^v1_1.EventMetadataStorage.address }}Address.zero(){{ /v1_1.EventMetadataStorage.address }}{{ #v1_1.EventMetadataStorage.address }}Address.fromString("{{ v1_1.EventMetadataStorage.address }}"){{ /v1_1.EventMetadataStorage.address }};
 export let BASEGET_ADDRESS_V1_1 = {{ ^v1_1.BaseGET.address }}Address.zero(){{ /v1_1.BaseGET.address }}{{ #v1_1.BaseGET.address }}Address.fromString("{{ v1_1.BaseGET.address }}"){{ /v1_1.BaseGET.address }};

--- a/src/constants/contracts.ts.mustache
+++ b/src/constants/contracts.ts.mustache
@@ -6,6 +6,7 @@ import { Address, BigInt } from "@graphprotocol/graph-ts";
 export let CHAIN_NAME = "{{ chainName }}".toUpperCase();
 export let CURRENCY_CONVERSION_ACTIVATED_BLOCK = BigInt.fromI32(20410204);
 export let GUTS_ON_CREDIT_BLOCK = BigInt.fromI32(39300544);
+export let STAKING_INIT_BLOCK = BigInt.fromI32(38542794);
 export let FUEL_BRIDGE_RECEIVER = Address.fromString("{{ addresses.FuelBridgeReceiver }}");
 export let STAKING = Address.fromString("{{ addresses.Staking }}");
 export let GET_SAAS = Address.fromString("{{ addresses.GETSaaS }}")

--- a/src/constants/fixed.ts
+++ b/src/constants/fixed.ts
@@ -3,7 +3,8 @@ import { Address, BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts";
 export let ADDRESS_ZERO = Address.zero();
 
 export let BIG_DECIMAL_ZERO = BigDecimal.fromString("0");
-export let BIG_DECIML_ONE = BigDecimal.fromString("1");
+export let BIG_DECIMAL_ONE = BigDecimal.fromString("1");
+export let BIG_DECIMAL_1E2 = BigDecimal.fromString("1e2");
 export let BIG_DECIMAL_1E3 = BigDecimal.fromString("1e3");
 export let BIG_DECIMAL_1E6 = BigDecimal.fromString("1e6");
 export let BIG_DECIMAL_1E12 = BigDecimal.fromString("1e12");

--- a/src/entities/integrator.ts
+++ b/src/entities/integrator.ts
@@ -37,6 +37,8 @@ export function getIntegrator(integratorIndex: string): Integrator {
     integrator.scannedCount = BIG_INT_ZERO;
     integrator.checkedInCount = BIG_INT_ZERO;
     integrator.claimedCount = BIG_INT_ZERO;
+    integrator.treasuryRevenue = BIG_DECIMAL_ZERO;
+    integrator.holdersRevenue = BIG_DECIMAL_ZERO;
   }
 
   return integrator as Integrator;
@@ -95,21 +97,39 @@ export function updateScanned(integratorIndex: string, count: BigInt): void {
   integrator.save();
 }
 
-export function updateCheckedIn(integratorIndex: string, count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateCheckedIn(
+  integratorIndex: string,
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let integrator = getIntegrator(integratorIndex);
   integrator.checkedInCount = integrator.checkedInCount.plus(count);
   integrator.spentFuel = integrator.spentFuel.plus(spentFuel);
   integrator.spentFuelProtocol = integrator.spentFuelProtocol.plus(spentFuelProtocol);
+  integrator.holdersRevenue = integrator.holdersRevenue.plus(holdersRevenue);
+  integrator.treasuryRevenue = integrator.treasuryRevenue.plus(treasuryRevenue);
   integrator.currentReservedFuel = integrator.currentReservedFuel.minus(spentFuel);
   integrator.currentReservedFuelProtocol = integrator.currentReservedFuelProtocol.minus(spentFuelProtocol);
   integrator.save();
 }
 
-export function updateInvalidated(integratorIndex: string, count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateInvalidated(
+  integratorIndex: string,
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let integrator = getIntegrator(integratorIndex);
   integrator.invalidatedCount = integrator.invalidatedCount.plus(count);
   integrator.spentFuel = integrator.spentFuel.plus(spentFuel);
   integrator.spentFuelProtocol = integrator.spentFuelProtocol.plus(spentFuelProtocol);
+  integrator.holdersRevenue = integrator.holdersRevenue.plus(holdersRevenue);
+  integrator.treasuryRevenue = integrator.treasuryRevenue.plus(treasuryRevenue);
   integrator.currentReservedFuel = integrator.currentReservedFuel.minus(spentFuel);
   integrator.currentReservedFuelProtocol = integrator.currentReservedFuelProtocol.minus(spentFuelProtocol);
   integrator.save();

--- a/src/entities/integrator.ts
+++ b/src/entities/integrator.ts
@@ -20,6 +20,7 @@ export function getIntegrator(integratorIndex: string): Integrator {
     integrator.activeTicketCount = 0;
     integrator.isBillingEnabled = true;
     integrator.isConfigured = true;
+    integrator.isOnCredit = false;
     integrator.minFeePrimary = BIG_DECIMAL_ZERO;
     integrator.maxFeePrimary = BIG_DECIMAL_ZERO;
     integrator.primaryRate = BIG_DECIMAL_ZERO;

--- a/src/entities/integratorDay.ts
+++ b/src/entities/integratorDay.ts
@@ -27,6 +27,8 @@ function getIntegratorDay(integratorIndex: string, day: i32): IntegratorDay {
     integratorDay.scannedCount = BIG_INT_ZERO;
     integratorDay.checkedInCount = BIG_INT_ZERO;
     integratorDay.claimedCount = BIG_INT_ZERO;
+    integratorDay.treasuryRevenue = BIG_DECIMAL_ZERO;
+    integratorDay.holdersRevenue = BIG_DECIMAL_ZERO;
   }
 
   return integratorDay as IntegratorDay;
@@ -84,12 +86,16 @@ export function updateCheckedIn(
   e: ethereum.Event,
   count: BigInt,
   spentFuel: BigDecimal,
-  spentFuelProtocol: BigDecimal
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
 ): void {
   let integratorDay = getIntegratorDayByIndexAndEvent(integratorIndex, e);
   integratorDay.checkedInCount = integratorDay.checkedInCount.plus(count);
   integratorDay.spentFuel = integratorDay.spentFuel.plus(spentFuel);
   integratorDay.spentFuelProtocol = integratorDay.spentFuelProtocol.plus(spentFuelProtocol);
+  integratorDay.holdersRevenue = integratorDay.holdersRevenue.plus(holdersRevenue);
+  integratorDay.treasuryRevenue = integratorDay.treasuryRevenue.plus(treasuryRevenue);
   integratorDay.save();
 }
 
@@ -98,12 +104,16 @@ export function updateInvalidated(
   e: ethereum.Event,
   count: BigInt,
   spentFuel: BigDecimal,
-  spentFuelProtocol: BigDecimal
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
 ): void {
   let integratorDay = getIntegratorDayByIndexAndEvent(integratorIndex, e);
   integratorDay.invalidatedCount = integratorDay.invalidatedCount.plus(count);
   integratorDay.spentFuel = integratorDay.spentFuel.plus(spentFuel);
   integratorDay.spentFuelProtocol = integratorDay.spentFuelProtocol.plus(spentFuelProtocol);
+  integratorDay.holdersRevenue = integratorDay.holdersRevenue.plus(holdersRevenue);
+  integratorDay.treasuryRevenue = integratorDay.treasuryRevenue.plus(treasuryRevenue);
   integratorDay.save();
 }
 

--- a/src/entities/protocol.ts
+++ b/src/entities/protocol.ts
@@ -88,16 +88,9 @@ export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelP
   protocol.save();
 }
 
-export function updateInvalidated(
-  count: BigInt,
-  spentFuel: BigDecimal,
-  spentFuelProtocol: BigDecimal,
-  holdersRevenue: BigDecimal
-  // treasuryRevenue: BigDecimal
-): void {
+export function updateInvalidated(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal, holdersRevenue: BigDecimal): void {
   let protocol = getProtocol();
   protocol.holdersRevenue = protocol.holdersRevenue.plus(holdersRevenue);
-  // protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.invalidatedCount = protocol.invalidatedCount.plus(count);
   protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
   protocol.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol.plus(spentFuelProtocol);

--- a/src/entities/protocol.ts
+++ b/src/entities/protocol.ts
@@ -29,12 +29,19 @@ export function getProtocol(): Protocol {
     protocol.checkedInCount = BIG_INT_ZERO;
     protocol.claimedCount = BIG_INT_ZERO;
     protocol.minFeePrimary = BIG_DECIMAL_ZERO;
+    protocol.treasuryRevenue = BIG_DECIMAL_ZERO;
+    protocol.holdersRevenue = BIG_DECIMAL_ZERO;
   }
 
   return protocol as Protocol;
 }
 
-export function updatePrimarySale(count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
+export function updatePrimarySale(
+  count: BigInt,
+  reservedFuel: BigDecimal,
+  reservedFuelProtocol: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocol = getProtocol();
   protocol.soldCount = protocol.soldCount.plus(count);
   protocol.reservedFuel = protocol.reservedFuel.plus(reservedFuel);
@@ -42,10 +49,16 @@ export function updatePrimarySale(count: BigInt, reservedFuel: BigDecimal, reser
   protocol.currentReservedFuel = protocol.currentReservedFuel.plus(reservedFuel);
   protocol.currentReservedFuelProtocol = protocol.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   protocol.averageReservedPerTicket = protocol.reservedFuel.div(protocol.soldCount.toBigDecimal());
+  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.save();
 }
 
-export function updateSecondarySale(count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
+export function updateSecondarySale(
+  count: BigInt,
+  reservedFuel: BigDecimal,
+  reservedFuelProtocol: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocol = getProtocol();
   protocol.resoldCount = protocol.resoldCount.plus(count);
   protocol.reservedFuel = protocol.reservedFuel.plus(reservedFuel);
@@ -53,6 +66,7 @@ export function updateSecondarySale(count: BigInt, reservedFuel: BigDecimal, res
   protocol.currentReservedFuel = protocol.currentReservedFuel.plus(reservedFuel);
   protocol.currentReservedFuelProtocol = protocol.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   protocol.averageReservedPerTicket = protocol.reservedFuel.div(protocol.soldCount.toBigDecimal());
+  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.save();
 }
 
@@ -74,8 +88,16 @@ export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelP
   protocol.save();
 }
 
-export function updateInvalidated(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateInvalidated(
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal
+  // treasuryRevenue: BigDecimal
+): void {
   let protocol = getProtocol();
+  protocol.holdersRevenue = protocol.holdersRevenue.plus(holdersRevenue);
+  // protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.invalidatedCount = protocol.invalidatedCount.plus(count);
   protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
   protocol.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol.plus(spentFuelProtocol);

--- a/src/entities/protocol.ts
+++ b/src/entities/protocol.ts
@@ -36,12 +36,7 @@ export function getProtocol(): Protocol {
   return protocol as Protocol;
 }
 
-export function updatePrimarySale(
-  count: BigInt,
-  reservedFuel: BigDecimal,
-  reservedFuelProtocol: BigDecimal,
-  treasuryRevenue: BigDecimal
-): void {
+export function updatePrimarySale(count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
   let protocol = getProtocol();
   protocol.soldCount = protocol.soldCount.plus(count);
   protocol.reservedFuel = protocol.reservedFuel.plus(reservedFuel);
@@ -49,16 +44,10 @@ export function updatePrimarySale(
   protocol.currentReservedFuel = protocol.currentReservedFuel.plus(reservedFuel);
   protocol.currentReservedFuelProtocol = protocol.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   protocol.averageReservedPerTicket = protocol.reservedFuel.div(protocol.soldCount.toBigDecimal());
-  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.save();
 }
 
-export function updateSecondarySale(
-  count: BigInt,
-  reservedFuel: BigDecimal,
-  reservedFuelProtocol: BigDecimal,
-  treasuryRevenue: BigDecimal
-): void {
+export function updateSecondarySale(count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
   let protocol = getProtocol();
   protocol.resoldCount = protocol.resoldCount.plus(count);
   protocol.reservedFuel = protocol.reservedFuel.plus(reservedFuel);
@@ -66,7 +55,6 @@ export function updateSecondarySale(
   protocol.currentReservedFuel = protocol.currentReservedFuel.plus(reservedFuel);
   protocol.currentReservedFuelProtocol = protocol.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   protocol.averageReservedPerTicket = protocol.reservedFuel.div(protocol.soldCount.toBigDecimal());
-  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.save();
 }
 
@@ -76,8 +64,15 @@ export function updateScanned(count: BigInt): void {
   protocol.save();
 }
 
-export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal, holdersRevenue: BigDecimal): void {
+export function updateCheckedIn(
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocol = getProtocol();
+  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.holdersRevenue = protocol.holdersRevenue.plus(holdersRevenue);
   protocol.checkedInCount = protocol.checkedInCount.plus(count);
   protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
@@ -89,8 +84,15 @@ export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelP
   protocol.save();
 }
 
-export function updateInvalidated(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal, holdersRevenue: BigDecimal): void {
+export function updateInvalidated(
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocol = getProtocol();
+  protocol.treasuryRevenue = protocol.treasuryRevenue.plus(treasuryRevenue);
   protocol.holdersRevenue = protocol.holdersRevenue.plus(holdersRevenue);
   protocol.invalidatedCount = protocol.invalidatedCount.plus(count);
   protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);

--- a/src/entities/protocol.ts
+++ b/src/entities/protocol.ts
@@ -76,8 +76,9 @@ export function updateScanned(count: BigInt): void {
   protocol.save();
 }
 
-export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateCheckedIn(count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal, holdersRevenue: BigDecimal): void {
   let protocol = getProtocol();
+  protocol.holdersRevenue = protocol.holdersRevenue.plus(holdersRevenue);
   protocol.checkedInCount = protocol.checkedInCount.plus(count);
   protocol.currentSpentFuel = protocol.currentSpentFuel.plus(spentFuel);
   protocol.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol.plus(spentFuelProtocol);

--- a/src/entities/protocolDay.ts
+++ b/src/entities/protocolDay.ts
@@ -80,9 +80,6 @@ export function updateCheckedIn(e: ethereum.Event, count: BigInt, spentFuel: Big
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
   protocolDay.checkedInCount = protocolDay.checkedInCount.plus(count);
-  //protocolDay.treasuryRevenue = protocolDay.treasuryRevenue + treasuryRevenue
-  // same for holdersRev
-
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);
   protocolDay.currentSpentFuel = protocol.currentSpentFuel;
@@ -96,13 +93,10 @@ export function updateInvalidated(
   spentFuel: BigDecimal,
   spentFuelProtocol: BigDecimal,
   holdersRevenue: BigDecimal
-  // treasuryRevenue: BigDecimal
 ): void {
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
-
   protocolDay.holdersRevenue = protocolDay.holdersRevenue.plus(holdersRevenue);
-  // protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
   protocolDay.invalidatedCount = protocolDay.invalidatedCount.plus(count);

--- a/src/entities/protocolDay.ts
+++ b/src/entities/protocolDay.ts
@@ -36,29 +36,16 @@ export function getProtocolDay(e: ethereum.Event): ProtocolDay {
   return protocolDay as ProtocolDay;
 }
 
-export function updatePrimarySale(
-  e: ethereum.Event,
-  count: BigInt,
-  reservedFuel: BigDecimal,
-  reservedFuelProtocol: BigDecimal,
-  treasuryRevenue: BigDecimal
-): void {
+export function updatePrimarySale(e: ethereum.Event, count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
   let protocolDay = getProtocolDay(e);
   protocolDay.soldCount = protocolDay.soldCount.plus(count);
   protocolDay.reservedFuel = protocolDay.reservedFuel.plus(reservedFuel);
   protocolDay.reservedFuelProtocol = protocolDay.reservedFuelProtocol.plus(reservedFuelProtocol);
   protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
-  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.save();
 }
 
-export function updateSecondarySale(
-  e: ethereum.Event,
-  count: BigInt,
-  reservedFuel: BigDecimal,
-  reservedFuelProtocol: BigDecimal,
-  treasuryRevenue: BigDecimal
-): void {
+export function updateSecondarySale(e: ethereum.Event, count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
   let protocolDay = getProtocolDay(e);
   protocolDay.resoldCount = protocolDay.resoldCount.plus(count);
   protocolDay.reservedFuel = protocolDay.reservedFuel.plus(reservedFuel);
@@ -66,7 +53,6 @@ export function updateSecondarySale(
   if (protocolDay.soldCount.gt(BIG_INT_ZERO)) {
     protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
   }
-  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.save();
 }
 
@@ -81,10 +67,12 @@ export function updateCheckedIn(
   count: BigInt,
   spentFuel: BigDecimal,
   spentFuelProtocol: BigDecimal,
-  holdersRevenue: BigDecimal
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
 ): void {
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
+  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.holdersRevenue = protocolDay.holdersRevenue.plus(holdersRevenue);
   protocolDay.checkedInCount = protocolDay.checkedInCount.plus(count);
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
@@ -99,10 +87,12 @@ export function updateInvalidated(
   count: BigInt,
   spentFuel: BigDecimal,
   spentFuelProtocol: BigDecimal,
-  holdersRevenue: BigDecimal
+  holdersRevenue: BigDecimal,
+  treasuryRevenue: BigDecimal
 ): void {
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
+  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.holdersRevenue = protocolDay.holdersRevenue.plus(holdersRevenue);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);

--- a/src/entities/protocolDay.ts
+++ b/src/entities/protocolDay.ts
@@ -29,21 +29,36 @@ export function getProtocolDay(e: ethereum.Event): ProtocolDay {
     protocolDay.scannedCount = BIG_INT_ZERO;
     protocolDay.checkedInCount = BIG_INT_ZERO;
     protocolDay.claimedCount = BIG_INT_ZERO;
+    protocolDay.treasuryRevenue = BIG_DECIMAL_ZERO;
+    protocolDay.holdersRevenue = BIG_DECIMAL_ZERO;
   }
 
   return protocolDay as ProtocolDay;
 }
 
-export function updatePrimarySale(e: ethereum.Event, count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
+export function updatePrimarySale(
+  e: ethereum.Event,
+  count: BigInt,
+  reservedFuel: BigDecimal,
+  reservedFuelProtocol: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocolDay = getProtocolDay(e);
   protocolDay.soldCount = protocolDay.soldCount.plus(count);
   protocolDay.reservedFuel = protocolDay.reservedFuel.plus(reservedFuel);
   protocolDay.reservedFuelProtocol = protocolDay.reservedFuelProtocol.plus(reservedFuelProtocol);
   protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
+  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.save();
 }
 
-export function updateSecondarySale(e: ethereum.Event, count: BigInt, reservedFuel: BigDecimal, reservedFuelProtocol: BigDecimal): void {
+export function updateSecondarySale(
+  e: ethereum.Event,
+  count: BigInt,
+  reservedFuel: BigDecimal,
+  reservedFuelProtocol: BigDecimal,
+  treasuryRevenue: BigDecimal
+): void {
   let protocolDay = getProtocolDay(e);
   protocolDay.resoldCount = protocolDay.resoldCount.plus(count);
   protocolDay.reservedFuel = protocolDay.reservedFuel.plus(reservedFuel);
@@ -51,6 +66,7 @@ export function updateSecondarySale(e: ethereum.Event, count: BigInt, reservedFu
   if (protocolDay.soldCount.gt(BIG_INT_ZERO)) {
     protocolDay.averageReservedPerTicket = protocolDay.reservedFuel.div(protocolDay.soldCount.toBigDecimal());
   }
+  protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.save();
 }
 
@@ -64,6 +80,9 @@ export function updateCheckedIn(e: ethereum.Event, count: BigInt, spentFuel: Big
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
   protocolDay.checkedInCount = protocolDay.checkedInCount.plus(count);
+  //protocolDay.treasuryRevenue = protocolDay.treasuryRevenue + treasuryRevenue
+  // same for holdersRev
+
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);
   protocolDay.currentSpentFuel = protocol.currentSpentFuel;
@@ -71,12 +90,22 @@ export function updateCheckedIn(e: ethereum.Event, count: BigInt, spentFuel: Big
   protocolDay.save();
 }
 
-export function updateInvalidated(e: ethereum.Event, count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateInvalidated(
+  e: ethereum.Event,
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal
+  // treasuryRevenue: BigDecimal
+): void {
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
-  protocolDay.invalidatedCount = protocolDay.invalidatedCount.plus(count);
-  protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
+
+  protocolDay.holdersRevenue = protocolDay.holdersRevenue.plus(holdersRevenue);
+  // protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(treasuryRevenue);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);
+  protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
+  protocolDay.invalidatedCount = protocolDay.invalidatedCount.plus(count);
   protocolDay.currentSpentFuel = protocol.currentSpentFuel;
   protocolDay.currentSpentFuelProtocol = protocol.currentSpentFuelProtocol;
   protocolDay.save();

--- a/src/entities/protocolDay.ts
+++ b/src/entities/protocolDay.ts
@@ -76,9 +76,16 @@ export function updateScanned(e: ethereum.Event, count: BigInt): void {
   protocolDay.save();
 }
 
-export function updateCheckedIn(e: ethereum.Event, count: BigInt, spentFuel: BigDecimal, spentFuelProtocol: BigDecimal): void {
+export function updateCheckedIn(
+  e: ethereum.Event,
+  count: BigInt,
+  spentFuel: BigDecimal,
+  spentFuelProtocol: BigDecimal,
+  holdersRevenue: BigDecimal
+): void {
   let protocolDay = getProtocolDay(e);
   let protocol = getProtocol();
+  protocolDay.holdersRevenue = protocolDay.holdersRevenue.plus(holdersRevenue);
   protocolDay.checkedInCount = protocolDay.checkedInCount.plus(count);
   protocolDay.spentFuel = protocolDay.spentFuel.plus(spentFuel);
   protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(spentFuelProtocol);

--- a/src/entities/spentFuelRecipient.ts
+++ b/src/entities/spentFuelRecipient.ts
@@ -1,6 +1,6 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal } from "@graphprotocol/graph-ts";
 import { SpentFuelRecipient } from "../../generated/schema";
-import { BIG_DECIMAL_ZERO } from "../constants";
+import { BIG_DECIMAL_ZERO, BIG_DECIMAL_1E2 } from "../constants";
 
 export function getSpentFuelRecipient(address: Address): SpentFuelRecipient {
   let spentFuelRecipient = SpentFuelRecipient.load(address.toHexString());
@@ -15,4 +15,14 @@ export function getSpentFuelRecipient(address: Address): SpentFuelRecipient {
   }
 
   return spentFuelRecipient as SpentFuelRecipient;
+}
+
+export function getSpentFuelRecipientPercentage(address: Address): BigDecimal {
+  let spentFuelRecipient = SpentFuelRecipient.load(address.toHexString());
+
+  if (spentFuelRecipient == null || !spentFuelRecipient.isEnabled) {
+    return BIG_DECIMAL_ZERO;
+  }
+
+  return spentFuelRecipient.percentage.div(BIG_DECIMAL_1E2);
 }

--- a/src/mappings/v1.1/baseGET.ts
+++ b/src/mappings/v1.1/baseGET.ts
@@ -175,16 +175,18 @@ export function handleTicketInvalidated(e: TicketInvalidated): void {
     // address. Because of this we can assume the getUsed to be the full reserved fuel for that ticket.
     let getUsed = ticket.reservedFuel;
 
-    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
     protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
+    billingIntegrator.treasuryRevenue = billingIntegrator.treasuryRevenue.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);
     billingIntegratorDay.spentFuelProtocol = billingIntegratorDay.spentFuelProtocol.plus(getUsed);
+    billingIntegratorDay.treasuryRevenue = billingIntegratorDay.treasuryRevenue.plus(getUsed);
 
     billingIntegrator.currentReservedFuel = billingIntegrator.currentReservedFuel.minus(getUsed);
     billingIntegrator.currentReservedFuelProtocol = billingIntegrator.currentReservedFuelProtocol.minus(getUsed);
@@ -260,16 +262,18 @@ export function handleTicketScanned(e: TicketScanned): void {
     let billingIntegratorDay = getIntegratorDayByIndexAndEvent(billingIntegrator.id, e);
     let getUsed = ticket.reservedFuel;
 
-    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
     protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
+    billingIntegrator.treasuryRevenue = billingIntegrator.treasuryRevenue.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);
     billingIntegratorDay.spentFuelProtocol = billingIntegratorDay.spentFuelProtocol.plus(getUsed);
+    billingIntegratorDay.treasuryRevenue = billingIntegratorDay.treasuryRevenue.plus(getUsed);
 
     billingIntegrator.currentReservedFuel = billingIntegrator.currentReservedFuel.minus(getUsed);
     billingIntegrator.currentReservedFuelProtocol = billingIntegrator.currentReservedFuelProtocol.minus(getUsed);
@@ -311,16 +315,18 @@ export function handleCheckedIn(e: CheckedIn): void {
     let billingIntegratorDay = getIntegratorDayByIndexAndEvent(billingIntegrator.id, e);
     let getUsed = ticket.reservedFuel;
 
-    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
     protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
+    billingIntegrator.treasuryRevenue = billingIntegrator.treasuryRevenue.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);
     billingIntegratorDay.spentFuelProtocol = billingIntegratorDay.spentFuelProtocol.plus(getUsed);
+    billingIntegratorDay.treasuryRevenue = billingIntegratorDay.treasuryRevenue.plus(getUsed);
 
     billingIntegrator.currentReservedFuel = billingIntegrator.currentReservedFuel.minus(getUsed);
     billingIntegrator.currentReservedFuelProtocol = billingIntegrator.currentReservedFuelProtocol.minus(getUsed);

--- a/src/mappings/v1.1/baseGET.ts
+++ b/src/mappings/v1.1/baseGET.ts
@@ -180,6 +180,7 @@ export function handleTicketInvalidated(e: TicketInvalidated): void {
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
+    protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);
@@ -264,6 +265,7 @@ export function handleTicketScanned(e: TicketScanned): void {
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
+    protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);
@@ -314,6 +316,7 @@ export function handleCheckedIn(e: CheckedIn): void {
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
     protocolDay.spentFuelProtocol = protocolDay.spentFuelProtocol.plus(getUsed);
+    protocolDay.treasuryRevenue = protocolDay.treasuryRevenue.plus(getUsed);
     billingIntegrator.spentFuel = billingIntegrator.spentFuel.plus(getUsed);
     billingIntegrator.spentFuelProtocol = billingIntegrator.spentFuelProtocol.plus(getUsed);
     billingIntegratorDay.spentFuel = billingIntegratorDay.spentFuel.plus(getUsed);

--- a/src/mappings/v1.1/baseGET.ts
+++ b/src/mappings/v1.1/baseGET.ts
@@ -175,6 +175,7 @@ export function handleTicketInvalidated(e: TicketInvalidated): void {
     // address. Because of this we can assume the getUsed to be the full reserved fuel for that ticket.
     let getUsed = ticket.reservedFuel;
 
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
@@ -258,6 +259,7 @@ export function handleTicketScanned(e: TicketScanned): void {
     let billingIntegratorDay = getIntegratorDayByIndexAndEvent(billingIntegrator.id, e);
     let getUsed = ticket.reservedFuel;
 
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);
@@ -307,6 +309,7 @@ export function handleCheckedIn(e: CheckedIn): void {
     let billingIntegratorDay = getIntegratorDayByIndexAndEvent(billingIntegrator.id, e);
     let getUsed = ticket.reservedFuel;
 
+    protocol.treasuryRevenue = protocol.treasuryRevenue.plus(getUsed);
     protocol.spentFuel = protocol.spentFuel.plus(getUsed);
     protocol.spentFuelProtocol = protocol.spentFuelProtocol.plus(getUsed);
     protocolDay.spentFuel = protocolDay.spentFuel.plus(getUsed);

--- a/src/mappings/v2/economics.ts
+++ b/src/mappings/v2/economics.ts
@@ -93,7 +93,7 @@ export function handleDisableIntegratorBilling(e: DisableIntegratorBilling): voi
 
 export function handleSetIntegratorOnCredit(e: UpdateIntegratorOnCredit): void {
   let integrator = getIntegrator(e.params.integratorIndex.toString());
-  integrator.isOnCredit = e.params.onCredit.toString() === "true";
+  integrator.isOnCredit = e.params.onCredit;
   integrator.save();
 }
 

--- a/src/mappings/v2/economics.ts
+++ b/src/mappings/v2/economics.ts
@@ -12,6 +12,7 @@ import {
   UpdateDynamicRates,
   UpdateIntegratorName,
   UpdateProtocolRates,
+  UpdateIntegratorOnCredit,
 } from "../../../generated/EconomicsV2/EconomicsV2";
 import { BIG_DECIMAL_1E18, BIG_DECIMAL_1E3, BIG_DECIMAL_ZERO, BIG_INT_ONE } from "../../constants";
 import { getIntegrator, getIntegratorDayByIndexAndEvent, getProtocol, getProtocolDay, getRelayer } from "../../entities";
@@ -87,6 +88,12 @@ export function handleEnableIntegratorBilling(e: EnableIntegratorBilling): void 
 export function handleDisableIntegratorBilling(e: DisableIntegratorBilling): void {
   let integrator = getIntegrator(e.params.integratorIndex.toString());
   integrator.isBillingEnabled = false;
+  integrator.save();
+}
+
+export function handleSetIntegratorOnCredit(e: UpdateIntegratorOnCredit): void {
+  let integrator = getIntegrator(e.params.integratorIndex.toString());
+  integrator.isOnCredit = e.params.onCredit.toString() === "true";
   integrator.save();
 }
 

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -118,11 +118,12 @@ export function handlePrimarySale(e: PrimarySale): void {
   protocol.updateTotalSalesVolume(cumulativeTicketValue);
   protocolDay.updateTotalSalesVolume(e, cumulativeTicketValue);
 
+  let treasuryRevenue = reservedFuelProtocol;
+  const day = protocolDay.getProtocolDay(e).day;
+
   let treasurySpentFuelRecipient = getSpentFuelRecipient(GET_SAAS);
   let percentageTreasury = treasurySpentFuelRecipient.percentage.div(BigDecimal.fromString("100"));
 
-  let treasuryRevenue = reservedFuelProtocol;
-  const day = protocolDay.getProtocolDay(e).day;
   if (!(day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) && !integratorInstance.isOnCredit) {
     const remainderReservedFuel = reservedFuel.minus(reservedFuelProtocol);
     treasuryRevenue = treasuryRevenue.plus(remainderReservedFuel.times(percentageTreasury));
@@ -249,12 +250,9 @@ export function handleCheckedIn(e: CheckedIn): void {
   const day = protocolDay.getProtocolDay(e).day;
   let holdersRevenue: BigDecimal;
 
-  if (
-    (day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) ||
-    (e.block.number.ge(GUTS_ON_CREDIT_BLOCK) && integratorInstance.isOnCredit)
-  ) {
+  if ((day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) || integratorInstance.isOnCredit) {
     holdersRevenue = remainder;
-  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK) && !integratorInstance.isOnCredit) {
+  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK)) {
     holdersRevenue = remainder.times(percentageEthStaking.plus(percentagePolyStaking));
   } else {
     holdersRevenue = BigDecimal.zero();
@@ -305,12 +303,9 @@ export function handleInvalidated(e: Invalidated): void {
   const day = protocolDay.getProtocolDay(e).day;
   let holdersRevenue: BigDecimal;
 
-  if (
-    (day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) ||
-    (e.block.number.ge(GUTS_ON_CREDIT_BLOCK) && integratorInstance.isOnCredit)
-  ) {
+  if ((day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) || integratorInstance.isOnCredit) {
     holdersRevenue = remainder;
-  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK) && !integratorInstance.isOnCredit) {
+  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK)) {
     holdersRevenue = remainder.times(percentageEthStaking.plus(percentagePolyStaking));
   } else {
     holdersRevenue = BigDecimal.zero();

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -119,7 +119,7 @@ export function handlePrimarySale(e: PrimarySale): void {
   let treasuryRevenue = reservedFuelProtocol;
   const day = protocolDay.getProtocolDay(e).day;
   if (day >= 19394 && eventInstance.integrator != "4") {
-    const remainderReservedFuel = reservedFuel.minus(reservedFuel);
+    const remainderReservedFuel = reservedFuel.minus(reservedFuelProtocol);
     treasuryRevenue = treasuryRevenue.plus(remainderReservedFuel.times(BigDecimal.fromString("0.8")));
   }
 
@@ -169,7 +169,7 @@ export function handleSecondarySale(e: SecondarySale): void {
   let treasuryRevenue = reservedFuelProtocol;
   const day = protocolDay.getProtocolDay(e).day;
   if (day >= 19394 && eventInstance.integrator != "4") {
-    const remainderReservedFuel = reservedFuel.minus(reservedFuel);
+    const remainderReservedFuel = reservedFuel.minus(reservedFuelProtocol);
     treasuryRevenue = treasuryRevenue.plus(remainderReservedFuel.times(BigDecimal.fromString("0.8")));
   }
 
@@ -232,19 +232,14 @@ export function handleCheckedIn(e: CheckedIn): void {
   const day = protocolDay.getProtocolDay(e).day;
   //day 19338 refers to 12th of December 2022
   let holdersRevenue: BigDecimal;
-  // let treasuryRevenue: BigDecimal;
-
   if (day >= 19338 && eventInstance.integrator == "4") {
     holdersRevenue = spentFuel;
-    // treasuryRevenue = BigDecimal.zero();
   }
   // when staking rewards start to accumulate
   else if (day >= 19394) {
     holdersRevenue = spentFuel.times(BigDecimal.fromString("0.2"));
-    // treasuryRevenue = spentFuel.times(BigDecimal.fromString("0.8"));
   } else {
     holdersRevenue = BigDecimal.zero();
-    // treasuryRevenue = spentFuel;
   }
 
   protocol.updateInvalidated(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);
@@ -283,19 +278,15 @@ export function handleInvalidated(e: Invalidated): void {
   const day = protocolDay.getProtocolDay(e).day;
   //day 19338 refers to 12th of December 2022
   let holdersRevenue: BigDecimal;
-  // let treasuryRevenue: BigDecimal;
   const remainder = spentFuel.minus(spentFuelProtocol);
   if (day >= 19338 && eventInstance.integrator == "4") {
     holdersRevenue = remainder;
-    // treasuryRevenue = BigDecimal.zero();
   }
   // when staking rewards start to accumulate
   else if (day >= 19394) {
     holdersRevenue = remainder.times(BigDecimal.fromString("0.2"));
-    // treasuryRevenue = remainder.times(BigDecimal.fromString("0.8"));
   } else {
     holdersRevenue = BigDecimal.zero();
-    // treasuryRevenue = remainder;
   }
 
   protocol.updateInvalidated(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -11,7 +11,7 @@ import {
   Transfer,
 } from "../../../generated/templates/EventImplementation/EventImplementation";
 import { BIG_DECIMAL_1E18, BIG_DECIMAL_1E3, BIG_DECIMAL_ZERO } from "../../constants";
-import { GUTS_ON_CREDIT_BLOCK, GET_SAAS, STAKING, FUEL_BRIDGE_RECEIVER } from "../../constants/contracts";
+import { GUTS_ON_CREDIT_BLOCK, GET_SAAS, STAKING, STAKING_INIT_BLOCK, FUEL_BRIDGE_RECEIVER } from "../../constants/contracts";
 import {
   calculateReservedFuelPrimary,
   calculateReservedFuelProtocol,
@@ -252,7 +252,7 @@ export function handleCheckedIn(e: CheckedIn): void {
 
   if ((day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) || integratorInstance.isOnCredit) {
     holdersRevenue = remainder;
-  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK)) {
+  } else if (e.block.number.ge(STAKING_INIT_BLOCK)) {
     holdersRevenue = remainder.times(percentageEthStaking.plus(percentagePolyStaking));
   } else {
     holdersRevenue = BigDecimal.zero();
@@ -305,7 +305,7 @@ export function handleInvalidated(e: Invalidated): void {
 
   if ((day >= 19338 && eventInstance.integrator == "4" && e.block.number.lt(GUTS_ON_CREDIT_BLOCK)) || integratorInstance.isOnCredit) {
     holdersRevenue = remainder;
-  } else if (e.block.number.ge(GUTS_ON_CREDIT_BLOCK)) {
+  } else if (e.block.number.ge(STAKING_INIT_BLOCK)) {
     holdersRevenue = remainder.times(percentageEthStaking.plus(percentagePolyStaking));
   } else {
     holdersRevenue = BigDecimal.zero();

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -255,8 +255,8 @@ export function handleCheckedIn(e: CheckedIn): void {
 
   protocol.updateCheckedIn(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
   protocolDay.updateCheckedIn(e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
-  integrator.updateCheckedIn(eventInstance.integrator, countBigInt, spentFuel, spentFuelProtocol);
-  integratorDay.updateCheckedIn(eventInstance.integrator, e, countBigInt, spentFuel, spentFuelProtocol);
+  integrator.updateCheckedIn(eventInstance.integrator, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
+  integratorDay.updateCheckedIn(eventInstance.integrator, e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
   event.updateCheckedIn(e.address, countBigInt);
 }
 
@@ -317,8 +317,8 @@ export function handleInvalidated(e: Invalidated): void {
 
   protocol.updateInvalidated(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
   protocolDay.updateInvalidated(e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
-  integrator.updateInvalidated(eventInstance.integrator, countBigInt, spentFuel, spentFuelProtocol);
-  integratorDay.updateInvalidated(eventInstance.integrator, e, countBigInt, spentFuel, spentFuelProtocol);
+  integrator.updateInvalidated(eventInstance.integrator, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
+  integratorDay.updateInvalidated(eventInstance.integrator, e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue, treasuryRevenue);
   event.updateInvalidated(e.address, countBigInt);
 }
 

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -242,8 +242,8 @@ export function handleCheckedIn(e: CheckedIn): void {
     holdersRevenue = BigDecimal.zero();
   }
 
-  protocol.updateInvalidated(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);
-  protocolDay.updateInvalidated(e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);
+  protocol.updateCheckedIn(countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);
+  protocolDay.updateCheckedIn(e, countBigInt, spentFuel, spentFuelProtocol, holdersRevenue);
   integrator.updateCheckedIn(eventInstance.integrator, countBigInt, spentFuel, spentFuelProtocol);
   integratorDay.updateCheckedIn(eventInstance.integrator, e, countBigInt, spentFuel, spentFuelProtocol);
   event.updateCheckedIn(e.address, countBigInt);

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -246,7 +246,6 @@ export function handleCheckedIn(e: CheckedIn): void {
   } else {
     let percentageEthStaking = getSpentFuelRecipientPercentage(FUEL_BRIDGE_RECEIVER);
     let percentagePolyStaking = getSpentFuelRecipientPercentage(STAKING);
-
     percentageTreasury = getSpentFuelRecipientPercentage(GET_SAAS);
     percentageStaking = percentageEthStaking.plus(percentagePolyStaking);
   }

--- a/subgraph.yaml.mustache
+++ b/subgraph.yaml.mustache
@@ -290,6 +290,8 @@ dataSources:
           handler: handleSpentFuelCollected
         - event: AccountBalanceCorrected(uint32,uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleAccountBalanceCorrected
+        - event: UpdateIntegratorOnCredit(uint32,bool)
+          handler: handleSetIntegratorOnCredit
         - event: UpdateProtocolRates((uint24,uint24,uint24,uint24,uint24,uint24,uint24))
           handler: handleUpdateProtocolRates
       file: ./src/mappings/v2/economics.ts


### PR DESCRIPTION
To provide more accurate information to DefiLlama and also to have proper tracking of fees and revenues, this PR is created. We added `holdersRevenue` and `treasuryRevenue`.

* `treasuryRevenue`: `protocolReservedFuel` and the `reservedFuel` from integrators that are not on credit.
* `holdersRevenue`: the amount of tokens pledged to stakers, calculated using `spentFuel`. 

In the PR, there are references to `day` numbers and integrator ids.
* `integrator id` 4 is GUTS Tickets
* `day` 19338 is the date that GUTS Tickets have become `onCredit`
* `day` 19394 is the date that GET Protocol launched staking.

Both `treasuryRevenue` and `holdersRevenue` can be tracked on `protocolDay` and `protocol`.