### PR TITLE
fix: wrong get used value emitted on ticket sales

### DIFF
--- a/src/constants/fixed.ts
+++ b/src/constants/fixed.ts
@@ -14,3 +14,5 @@ export let BIG_INT_ZERO = BigInt.fromI32(0);
 export let BIG_INT_ONE = BigInt.fromI32(1);
 
 export let BYTES_EMPTY = Bytes.empty();
+
+export let V2_1_FUEL_FIX_BLOCK = BigInt.fromI32(56450784); // This is a dummy number and would be replaced with the actual blockheight after our contract upgrade

--- a/src/entities/integrator.ts
+++ b/src/entities/integrator.ts
@@ -99,8 +99,8 @@ export function updateSecondarySale(
   integrator.resoldCount = integrator.resoldCount.plus(count);
   integrator.reservedFuel = integrator.reservedFuel.plus(reservedFuel);
   integrator.reservedFuelProtocol = integrator.reservedFuelProtocol.plus(reservedFuelProtocol);
-  integrator.spentFuel = integrator.spentFuel.plus(reservedFuel);
-  integrator.spentFuelProtocol = integrator.spentFuelProtocol.plus(reservedFuelProtocol);
+  integrator.currentReservedFuel = integrator.currentReservedFuel.plus(reservedFuel);
+  integrator.currentReservedFuelProtocol = integrator.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   integrator.averageReservedPerTicket = integrator.reservedFuel.div(integrator.soldCount.toBigDecimal());
   integrator.availableFuel = integrator.availableFuel.minus(reservedFuel);
 

--- a/src/entities/integrator.ts
+++ b/src/entities/integrator.ts
@@ -75,6 +75,16 @@ export function updatePrimarySale(
   integrator.currentReservedFuelProtocol = integrator.currentReservedFuelProtocol.plus(reservedFuelProtocol);
   integrator.averageReservedPerTicket = integrator.reservedFuel.div(integrator.soldCount.toBigDecimal());
   integrator.availableFuel = integrator.availableFuel.minus(reservedFuel);
+
+  // This value may slightly diverge from the actual values provided on chain. This is because in the new
+  // V2.1 contracts, there's no concept of an average price of fuel as fuel isn't mixed together during top ups.
+  // Fuel is represented as individual installments which we call `ticks`. Each tick is characterized by the fuel
+  // amount and price at top up. We deplete fuel from an integrator from it's ticks in a FIFO basis.
+  // I.e we charge fuel based on a price of P1 of a tick T1 untill it's fully depleted and we move onto the price
+  // P2 of tick T2 and so on and forth.
+  // It's important to note however, that while these values may diverge initially (subgraph and on chain values),
+  // because of the earlier explained factors, these divergence is smothened out over time because the average price
+  // model would equate to same values of fuel used/charged via the tick FIFO model over a given period of time.
   integrator.availableFuelUSD = integrator.availableFuelUSD.minus(reservedFuel.times(integrator.price));
   integrator.save();
 }
@@ -89,10 +99,12 @@ export function updateSecondarySale(
   integrator.resoldCount = integrator.resoldCount.plus(count);
   integrator.reservedFuel = integrator.reservedFuel.plus(reservedFuel);
   integrator.reservedFuelProtocol = integrator.reservedFuelProtocol.plus(reservedFuelProtocol);
-  integrator.currentReservedFuel = integrator.currentReservedFuel.plus(reservedFuel);
-  integrator.currentReservedFuelProtocol = integrator.currentReservedFuelProtocol.plus(reservedFuelProtocol);
+  integrator.spentFuel = integrator.spentFuel.plus(reservedFuel);
+  integrator.spentFuelProtocol = integrator.spentFuelProtocol.plus(reservedFuelProtocol);
   integrator.averageReservedPerTicket = integrator.reservedFuel.div(integrator.soldCount.toBigDecimal());
   integrator.availableFuel = integrator.availableFuel.minus(reservedFuel);
+
+  // Same idea explained for the `availableFuelUSD` on the updatePrimarySale function holds true here
   integrator.availableFuelUSD = integrator.availableFuelUSD.minus(reservedFuel.times(integrator.price));
   integrator.save();
 }

--- a/src/mappings/v2.1/economicsFactory.ts
+++ b/src/mappings/v2.1/economicsFactory.ts
@@ -122,6 +122,7 @@ export function handleIntegratorToppedUp(e: IntegratorToppedUp): void {
 
   integrator.totalTopUp = totalTopUp;
   integrator.totalTopUpUSD = totalTopUpUSD;
+  integrator.price = totalTopUpUSD.div(totalTopUp);
 
   integrator.topUpCount = integrator.topUpCount.plus(BIG_INT_ONE);
   integratorDay.topUpCount = integratorDay.topUpCount.plus(BIG_INT_ONE);


### PR DESCRIPTION
Due to a bug in the contracts, we added the  protocolFuel twice in the `getUsed` value emitted by sale events. This caused a divergence between the subgraph and on chain fuel balances. This commit fixes this issue.