### PR TITLE
fix: handle empty ticket actions on action events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Prepare subgraph.yaml
-        run: yarn prepare:polygon-production
+        run: yarn prepare:polygon-production && yarn prepare:polygon-production-v1
       - name: Generate types
         run: yarn codegen
       - name: Run linting checks

--- a/src/mappings/v2/eventImplementation.ts
+++ b/src/mappings/v2/eventImplementation.ts
@@ -13,7 +13,7 @@ import {
   SecondarySale1,
   Transfer,
 } from "../../../generated/templates/EventImplementation/EventImplementation";
-import { BIG_DECIMAL_1E15, BIG_DECIMAL_1E18, BIG_DECIMAL_1E3, BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO } from "../../constants";
+import { BIG_DECIMAL_1E15, BIG_DECIMAL_1E18, BIG_DECIMAL_1E3, BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO, BIG_INT_ZERO } from "../../constants";
 import {
   GUTS_ON_CREDIT_BLOCK,
   GET_SAAS,
@@ -450,6 +450,11 @@ export function handleTransfer(e: Transfer): void {
 export function handlePrimarySaleV2_2(e: PrimarySale1): void {
   let count = e.params.ticketActions.length;
   let countBigInt = BigInt.fromI32(count);
+
+  if (countBigInt.equals(BIG_INT_ZERO)) {
+    return;
+  }
+
   let reservedFuel = e.params.fuelTokens.divDecimal(BIG_DECIMAL_1E18);
   let reservedFuelProtocol = e.params.fuelTokensProtocol.divDecimal(BIG_DECIMAL_1E18);
   let reservedFuelUSD = e.params.fuelUSD.divDecimal(BIG_DECIMAL_1E18);
@@ -516,6 +521,11 @@ export function handlePrimarySaleV2_2(e: PrimarySale1): void {
 export function handleSecondarySaleV2_2(e: SecondarySale1): void {
   let count = e.params.ticketActions.length;
   let countBigInt = BigInt.fromI32(count);
+
+  if (countBigInt.equals(BIG_INT_ZERO)) {
+    return;
+  }
+
   let reservedFuel = e.params.fuelTokens.divDecimal(BIG_DECIMAL_1E18);
   let reservedFuelProtocol = e.params.fuelTokensProtocol.divDecimal(BIG_DECIMAL_1E18);
   let reservedFuelUSD = e.params.fuelUSD.divDecimal(BIG_DECIMAL_1E18);
@@ -575,6 +585,11 @@ export function handleSecondarySaleV2_2(e: SecondarySale1): void {
 export function handleClaimedV2_2(e: Claimed1): void {
   let count = e.params.ticketActions.length;
   let countBigInt = BigInt.fromI32(count);
+
+  if (countBigInt.equals(BIG_INT_ZERO)) {
+    return;
+  }
+
   let eventInstance = getEvent(e.address);
 
   for (let i = 0; i < count; ++i) {


### PR DESCRIPTION
Prior to now there was no need for this fix because any action within a batch that didn't pass the action rules would have the batch reverted. This was changed in favour of dropping those actions and emitting them as ActionErrorLogs.
This has made it possible for all actions to be dropped and have an action event emitted with an empty array of ticket actions. When this happen, we just ignore that event.